### PR TITLE
Remove support for v12

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -71,7 +71,7 @@ jobs:
               with:
                   type: "zip"
                   filename: "${{steps.id.outputs.prop}}.zip"
-                  exclusions: "*.git* /*node_modules/* /*.vscode/* .npmignore .nvmrc gulpfile.js package-lock.json package.json /src/* /scss/* /sass/* /*.cmd/*"
+                  exclusions: "*.git* /*node_modules/* /*.vscode/* .npmignore .nvmrc gulpfile.js package-lock.json package.json /src/* /scss/* /sass/* /*.cmd/* .yaml"
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v1
               with:

--- a/.github/workflows/staging-builder.yml
+++ b/.github/workflows/staging-builder.yml
@@ -65,7 +65,7 @@ jobs:
               with:
                   type: "zip"
                   filename: "${{steps.id.outputs.prop}}.zip"
-                  exclusions: "*.git* /*node_modules/* /*.vscode/* .npmignore .nvmrc gulpfile.js package-lock.json package.json /src/* /scss/* /sass/* /*.cmd/*"
+                  exclusions: "*.git* /*node_modules/* /*.vscode/* .npmignore .nvmrc gulpfile.js package-lock.json package.json /src/* /scss/* /sass/* /*.cmd/* .yaml"
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v1
               with:

--- a/system.json
+++ b/system.json
@@ -2,9 +2,9 @@
 	"id": "metanthropes",
 	"title": "Metanthropes",
 	"description": "Metanthropes TTRPG System for Foundry VTT by Legitamine Games",
-	"version": "0.13.1",
+	"version": "0.13.2",
 	"compatibility": {
-		"minimum": "12",
+		"minimum": "13",
 		"verified": "13.340",
 		"maximum": "13"
 	},


### PR DESCRIPTION
The introduction of CSS layers makes it tricky to support properly both V12 & V13 so moving to strictly V13 onwards.