### PR TITLE
Improve intellisense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ dist/
 # Temp Foundry Runtime Files
 foundry/
 *.lock
-jsconfig.json
 
 # Improving Intellisense
 foundry-config.yaml

--- a/config.d.ts
+++ b/config.d.ts
@@ -1,3 +1,7 @@
+import "@client/global.mjs";
+import "@common/primitives/global.d.mts";
+import "@common/primitives/global.mjs";
+
 declare global {
 	// not a real extension of course but simplest way for this to work with the intellisense.
 	/**

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "ES2022",
+    "target": "ES2024",
+    "paths": {
+      "@client/*": ["./foundry/client/*"],
+      "@common/*": ["./foundry/common/*"]
+    }
+  },
+  "exclude": ["node_modules", "**/node_modules/*"],
+  "include": ["module/metanthropes.mjs", "foundry/client/client.mjs", "config.d.ts"],
+  "typeAcquisition": {
+    "include": ["jquery"]
+  }
+}


### PR DESCRIPTION
Adds a jsconfig file with entry points (and removes it from gitignore), plus some additional entry points in for intellisense in config.d.ts.

I was not seeing the global objects `metanthropes` or `foundry` available in files for the purpose of intellisense (auto-complete); this PR resolves that.